### PR TITLE
緯度経度データを履歴を利用したキャッシュ機構の実装

### DIFF
--- a/app/controllers/api/v1/shops_controller.rb
+++ b/app/controllers/api/v1/shops_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative('../../../../db/seeds')
+
 module Api
   module V1
     class ShopsController < ApplicationController
@@ -8,16 +10,42 @@ module Api
         render json: shop
       end
 
-      def sort_by_near
-        latitude = params[:latitude]
-        longitude = params[:longitude]
+      def get_near_data_from_db(latitude, longitude, limit)
         @address = Address.all
         @address = @address.order_location_by(
           latitude, longitude
         )
-        @address = @address.includes(:shop).limit(params[:limit])
-        @shop = @address.map { |adrs| adrs.shop }
-        render json: { status: 'SUCCESS', message: 'Loaded the shop sort by distance', data: @shop }
+        @address = @address.includes(:shop).limit(limit)
+        @shops = @address.map { |adrs| adrs.shop }
+        @shops
+      end
+
+      def get_near_data_from_gcp(latitude, longitude, limit)
+        seed_maker = SeedMaker.new(keyword: 'ラーメン',
+                                   save_photo: false,
+                                   limit: limit,
+                                   latitude: latitude,
+                                   longitude: longitude)
+        @shops = seed_maker.run
+        @shops
+      end
+
+      def sort_by_near
+        latitude = params[:latitude]
+        longitude = params[:longitude]
+        limit = params[:limit]
+
+        round_lat = latitude.to_f.round(3)
+        round_lon = longitude.to_f.round(3)
+        @lat_lon = LatLon.find_by(latitude: round_lat, longitude: round_lon)
+
+        @shops = if @lat_lon.nil?
+                   get_near_data_from_gcp(latitude, longitude, limit)
+                 else
+                   get_near_data_from_db(latitude, longitude, limit)
+                 end
+
+        render json: { status: 'SUCCESS', message: 'Loaded the shop sort by distance', data: @shops }
       end
 
       def show

--- a/app/models/lat_lon.rb
+++ b/app/models/lat_lon.rb
@@ -1,0 +1,2 @@
+class LatLon < ApplicationRecord
+end

--- a/app/models/lat_lon.rb
+++ b/app/models/lat_lon.rb
@@ -1,2 +1,3 @@
 class LatLon < ApplicationRecord
+  has_many :shops
 end

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Shop < ApplicationRecord
+  belongs_to :lat_lon
   has_many :reviews, dependent: :destroy
   has_many :photos, dependent: :destroy
   has_one :address

--- a/app/services/gcp_utils.rb
+++ b/app/services/gcp_utils.rb
@@ -6,14 +6,14 @@ require 'nokogiri'
 
 API_KEY = File.open('./GCP_API_KEY').read
 
-def nearbysearch_url_maker(loc: -33.8670522,
-                           lat: 151.1957362,
+def nearbysearch_url_maker(lat: -33.8670522,
+                           lon: 151.1957362,
                            radius: 15_000,
                            type: 'restaurant',
                            keyword: 'meat')
 
   default_url = 'https://maps.googleapis.com/maps/api/place/nearbysearch/json?'
-  url = "#{default_url}location=#{loc},#{lat}&radius=#{radius}&type=#{type}&keyword=#{keyword}&key=#{API_KEY}"
+  url = "#{default_url}location=#{lat},#{lon}&radius=#{radius}&type=#{type}&keyword=#{keyword}&key=#{API_KEY}"
   URI.encode(url)
 end
 

--- a/app/services/gcp_utils.rb
+++ b/app/services/gcp_utils.rb
@@ -13,7 +13,7 @@ def nearbysearch_url_maker(loc: -33.8670522,
                            keyword: 'meat')
 
   default_url = 'https://maps.googleapis.com/maps/api/place/nearbysearch/json?'
-  url = "#{default_url}location=#{loc},#{lat}&radius=#{radius}&type=#{type}&keyword=#{keyword}&key=#{API_KEY}"
+  url = "#{default_url}location=#{loc},#{lat}&radius=#{radius}&type=#{type}&keyword=#{keyword}&key=#{API_KEY}&language=ja"
   URI.encode(url)
 end
 
@@ -21,13 +21,13 @@ def find_url_maker(place_id:,
                    fields: 'name,rating,formatted_phone_number,geometry')
 
   default_url = 'https://maps.googleapis.com/maps/api/place/details/json?'
-  url = "#{default_url}place_id=#{place_id}&fields=#{fields}&key=#{API_KEY}"
+  url = "#{default_url}place_id=#{place_id}&fields=#{fields}&key=#{API_KEY}&language=ja"
   URI.encode(url)
 end
 
 def photo_url_maker(photo_ref, w_and_h)
   default_url = 'https://maps.googleapis.com/maps/api/place/photo?'
-  url = "#{default_url}maxwidth=#{w_and_h}&maxheight=#{w_and_h}&photoreference=#{photo_ref}&key=#{API_KEY}"
+  url = "#{default_url}maxwidth=#{w_and_h}&maxheight=#{w_and_h}&photoreference=#{photo_ref}&key=#{API_KEY}&language=ja"
   URI.encode(url)
 end
 

--- a/db/migrate/20210503224700_create_lat_lons.rb
+++ b/db/migrate/20210503224700_create_lat_lons.rb
@@ -1,0 +1,10 @@
+class CreateLatLons < ActiveRecord::Migration[5.2]
+  def change
+    create_table :lat_lons do |t|
+      t.float :latitude
+      t.float :longitude
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210504013003_add_lat_lon_id_to_shops.rb
+++ b/db/migrate/20210504013003_add_lat_lon_id_to_shops.rb
@@ -1,0 +1,5 @@
+class AddLatLonIdToShops < ActiveRecord::Migration[5.2]
+  def change
+    add_column :shops, :lat_lon_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_03_224700) do
+ActiveRecord::Schema.define(version: 2021_05_04_013003) do
 
   create_table "addresses", force: :cascade do |t|
     t.integer "shop_id"
@@ -57,6 +57,7 @@ ActiveRecord::Schema.define(version: 2021_05_03_224700) do
     t.datetime "updated_at", null: false
     t.string "place_id"
     t.string "opening_hours"
+    t.integer "lat_lon_id"
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_29_233823) do
+ActiveRecord::Schema.define(version: 2021_05_03_224700) do
 
   create_table "addresses", force: :cascade do |t|
     t.integer "shop_id"
@@ -22,6 +22,13 @@ ActiveRecord::Schema.define(version: 2021_04_29_233823) do
     t.string "locality"
     t.string "thoroughfare"
     t.string "sub_thoroughfare"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "lat_lons", force: :cascade do |t|
+    t.float "latitude"
+    t.float "longitude"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,9 +11,18 @@
 Dir.glob(File.join(File.dirname(__FILE__), '../app/services/**/*.rb')).each { |f| require f }
 
 class SeedMaker
-  def initialize(keyword: 'meat')
+  def initialize(keyword: 'meat',
+                 save_photo: false,
+                 limit: 5,
+                 latitude: 35.61,
+                 longitude: 139.65)
     @nearby_url = nearbysearch_url_maker(keyword: keyword)
     @neigbor_results = request_result(url: @nearby_url, key: 'results')
+    @limit = limit
+    @save_photo = save_photo
+    @latitude = latitude
+    @longitude = longitude
+    self.inspect
   end
 
   def get_detail_result(neigbor_result)
@@ -24,48 +33,62 @@ class SeedMaker
   end
 
   def run
+    @lat_lon = self.lat_lon
+    shop_array = []
     @neigbor_results.each_with_index do |neigbor_result, idx|
       puts idx
       detail_result = self.get_detail_result(neigbor_result)
-      shop = self.shop(detail_result)
-      self.address(shop, detail_result)
-      self.review(shop, detail_result)
-      self.photo(shop, detail_result)
+      @shop = self.shop(detail_result)
+      self.address(detail_result)
+      self.review(detail_result)
+      self.photo(detail_result) if @save_photo
+      shop_array.append(@shop)
+      break if idx == @limit
     end
+    shop_array
+  end
+
+  def lat_lon
+    lat_lon = LatLon.new(latitude: @latitude, longitude: @longitude)
+    lat_lon.save
+    lat_lon
   end
 
   def shop(detail_result)
-    shop = Shop.create
-    shop = shop.from_result(detail_result, @pid)
+    shop = @lat_lon.shops.create
+    shop.from_result(detail_result, @pid)
     shop.save
     shop
   end
 
-  def address(shop, detail_result)
-    address = shop.create_address
+  def address(detail_result)
+    address = @shop.create_address
     address = address.from_result(detail_result)
     address.save
     address
   end
 
-  def review(shop, detail_result)
+  def review(detail_result)
     detail_result['reviews'].each do |review_data|
-      review = shop.reviews.create
+      review = @shop.reviews.create
       review = review.from_result(review_data)
       review.save
     end
   end
 
-  def photo(shop, detail_result)
+  def photo(detail_result)
     detail_result['photos'].each_with_index do |photo_data, idx|
-      photo = shop.photos.create
+      photo = @shop.photos.create
       photo_ref = photo_data['photo_reference']
-      photo = photo.photo_ref_to_save(photo_ref, shop.place_id, idx)
+      photo = photo.photo_ref_to_save(photo_ref, @shop.place_id, idx)
       photo.save
       break if idx == 2
     end
   end
 end
 
-seed_maker = SeedMaker.new
-seed_maker.run
+# TODO: 実行部とclass定義のfileを分ける
+if __FILE__ == $PROGRAM_NAME
+  seed_maker = SeedMaker.new
+  seed_maker.run
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -49,7 +49,9 @@ class SeedMaker
   end
 
   def lat_lon
-    lat_lon = LatLon.new(latitude: @latitude, longitude: @longitude)
+    round_lat = @latitude.to_f.round(3)
+    round_lon = @longitude.to_f.round(3)
+    lat_lon = LatLon.new(latitude: round_lat, longitude: round_lon)
     lat_lon.save
     lat_lon
   end

--- a/spec/models/lat_lon_spec.rb
+++ b/spec/models/lat_lon_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe LatLon, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/shop_spec.rb
+++ b/spec/models/shop_spec.rb
@@ -1,8 +1,17 @@
 require 'rails_helper'
 
 RSpec.describe Shop, type: :model do
+  latitude = 35.61
+  longitude = 139.65
+
+  let(:lat_lon) do
+    LatLon.new(latitude: latitude, longitude: longitude)
+  end
+
   let(:shop) do
-    url = nearbysearch_url_maker(keyword: 'meat')
+    url = nearbysearch_url_maker(keyword: 'meat',
+                                 lat: latitude,
+                                 lon: longitude)
     results = request_result(url: url, key: 'results')
     place_id = results[0]['place_id']
 
@@ -10,10 +19,11 @@ RSpec.describe Shop, type: :model do
     url = find_url_maker(place_id: place_id, fields: fields)
     result = request_result(url: url, key: 'result')
 
-    shop = Shop.new
+    shop = lat_lon.shops.build
     shop.from_result(result, place_id)
   end
 
+  # TODO: lat_lonをrelationに追加したので、落ちる
   subject { shop.valid? }
   it 'indicate that Shop can be generated from cls method.' do
     is_expected.to eq true

--- a/spec/requests/shop_spec.rb
+++ b/spec/requests/shop_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe 'Shops', type: :request do
+  describe 'GET #sort_by_near' do
+    it 'responds successfully' do
+      get '/api/v1/shops/near?latitude=40&longitude=40&distance=4000'
+      expect(response).to be_success
+    end
+  end
+end


### PR DESCRIPTION
Why:
毎回データをgcpから取得するとAPIの使用制限を超えてしまうため、
過去にアクセスされた緯度経度からアクセスされた場合はDBからデータを返すようにしたい。

What:
`shop_controller`の`sort_by_near` にて、緯度経度テーブルの中身を参照し、
過去に近い緯度経度が存在すれば、DBから返却し、そうでなければGCPから取得するようにした。


